### PR TITLE
Added Trello board links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ This repository exists to provide a central place where we can put public items 
 We expect the issues in this repository to be pretty active, but they may be rather high level. If a high level task gets created in this repository, we can create a list of sub-issues in individual project repositories that need to be completed to close it.
 
 If you identify an issue within any part of a Tidepool system and you don't know where to file it, please file it here, and we'll triage it into the right place.
+
+The links to the public Trello boards that coincide with the issues in this repo are:
+* [Platform Board](https://trello.com/b/xLF1XmeQ/platform) - This board details all of the current back-end tasks
+* [Blip Board](https://trello.com/b/GPadCYvP/blip) - This board details all of the current blip-related tasks


### PR DESCRIPTION
Since the Trello boards are public, I added the links to the README for easier access.
