### PR TITLE
Update README.md with additional Trello links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,9 @@ If you identify an issue within any part of a Tidepool system and you don't know
 
 The links to the public Trello boards that coincide with the issues in this repo are:
 * [Platform Board](https://trello.com/b/xLF1XmeQ/platform) - This board details all of the current back-end tasks
+* [Platform Roadmap](https://trello.com/b/48QNdfoh/platform-roadmap) - Roadmap for Tidepool platform development. Any tasks on the Wish List with a brown label are open for contribution.
 * [Blip Board](https://trello.com/b/GPadCYvP/blip) - This board details all of the current blip-related tasks
+* [Blip Product Backlog](https://trello.com/b/iKydvoiJ/blip-product-backlog) 
+* [Open Source Tasks](https://trello.com/b/uTNKzwka/open-source-tasks) - Tasks across all projects that are open for contribution.
+
+If you start work on a card from any of the Trello boards, please talk with us so we know you're working on it.


### PR DESCRIPTION
I added the Open Source Tasks, Platform Roadmap, and Blip Product Backlog board links to the README for easy access.
